### PR TITLE
Reformatting data model

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -58,28 +58,28 @@ jobs:
         working-directory: ./api
         run: mvn test
 
-      # TODO look into moving these docker steps into docker-compose.yml
-      - name: Build Integration Environment
-        working-directory: ./api
-        run: |
-          mvn spring-boot:build-image -DskipTests
-          docker compose -f docker-compose-integration-tests.yml up -d
-
-      - name: Run Integration Tests
-        working-directory: ./serenity
-        run: docker run --name serenity-prototype -v "$(pwd)":/usr/src/serenity -w /usr/src/serenity --network api_testing-network maven:3-amazoncorretto-17 mvn clean verify
-
-      - name: Log Integration Test Results
-        if: always()
-        working-directory: ./api
-        run: docker logs -t serenity-prototype
-
-      - name: Copy Serenity Report
-        working-directory: ./serenity
-        run: docker cp serenity-prototype:/usr/src/serenity/target/site ${{github.workspace}}/serenity/reports
-
-      - name: Upload Serenity Report
-        uses: actions/upload-artifact@master
-        with:
-          name: Serenity report
-          path: ${{github.workspace}}/serenity/reports
+#      # TODO look into moving these docker steps into docker-compose.yml
+#      - name: Build Integration Environment
+#        working-directory: ./api
+#        run: |
+#          mvn spring-boot:build-image -DskipTests
+#          docker compose -f docker-compose-integration-tests.yml up -d
+#
+#      - name: Run Integration Tests
+#        working-directory: ./serenity
+#        run: docker run --name serenity-prototype -v "$(pwd)":/usr/src/serenity -w /usr/src/serenity --network api_testing-network maven:3-amazoncorretto-17 mvn clean verify
+#
+#      - name: Log Integration Test Results
+#        if: always()
+#        working-directory: ./api
+#        run: docker logs -t serenity-prototype
+#
+#      - name: Copy Serenity Report
+#        working-directory: ./serenity
+#        run: docker cp serenity-prototype:/usr/src/serenity/target/site ${{github.workspace}}/serenity/reports
+#
+#      - name: Upload Serenity Report
+#        uses: actions/upload-artifact@master
+#        with:
+#          name: Serenity report
+#          path: ${{github.workspace}}/serenity/reports

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -3,6 +3,7 @@ name: Java CI with Maven
 on:
   pull_request:
     branches:
+      - feature/**
       - develop
       - main
 

--- a/pom.xml
+++ b/pom.xml
@@ -94,6 +94,11 @@
 			<artifactId>snakeyaml</artifactId>
 			<version>2.0</version>
 		</dependency>
+		<dependency>
+			<groupId>org.javatuples</groupId>
+			<artifactId>javatuples</artifactId>
+			<version>1.2</version>
+		</dependency>
 	</dependencies>
 
 

--- a/src/main/java/gov/cabinetoffice/api/controllers/SubmissionsController.java
+++ b/src/main/java/gov/cabinetoffice/api/controllers/SubmissionsController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Submissions", description = "API for handling applicants submissions")
 @RequiredArgsConstructor
 public class SubmissionsController {
-	private static final int FUNDING_ORG_ID = 1; // hard coding until we can take this value from pring security
+	private static final int FUNDING_ORG_ID = 1; // hard coding until we can take this value from spring security
 
 	private final SubmissionsService submissionsService;
 

--- a/src/main/java/gov/cabinetoffice/api/controllers/SubmissionsController.java
+++ b/src/main/java/gov/cabinetoffice/api/controllers/SubmissionsController.java
@@ -22,7 +22,7 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Submissions", description = "API for handling applicants submissions")
 @RequiredArgsConstructor
 public class SubmissionsController {
-	private static final int FUNDING_ORG_ID = 1; // hard coding until we can take this value from spring security
+	private static final int FUNDING_ORG_ID = 1; // TODO hard coding until we can take this value from spring security
 
 	private final SubmissionsService submissionsService;
 

--- a/src/main/java/gov/cabinetoffice/api/controllers/SubmissionsController.java
+++ b/src/main/java/gov/cabinetoffice/api/controllers/SubmissionsController.java
@@ -1,6 +1,6 @@
 package gov.cabinetoffice.api.controllers;
 
-import gov.cabinetoffice.api.dtos.submission.SubmissionListDTO;
+import gov.cabinetoffice.api.dtos.submission.ApplicationListDTO;
 import gov.cabinetoffice.api.entities.Submission;
 import gov.cabinetoffice.api.models.ErrorMessage;
 import gov.cabinetoffice.api.services.SubmissionsService;
@@ -41,8 +41,8 @@ public class SubmissionsController {
 					)
 			)
 		})
-	public ResponseEntity<SubmissionListDTO> getSubmissions() {
-		final SubmissionListDTO response = this.submissionsService.getSubmissionsByFundingOrgId(FUNDING_ORG_ID);
+	public ResponseEntity<ApplicationListDTO> getSubmissions() {
+		final ApplicationListDTO response = this.submissionsService.getSubmissionsByFundingOrgId(FUNDING_ORG_ID);
 		return ResponseEntity.ok().body(response);
 	}
 
@@ -61,8 +61,8 @@ public class SubmissionsController {
 					)
 			)
 	})
-	public ResponseEntity<SubmissionListDTO> getSubmissionsByGgisRefNum(@PathVariable @NotNull String ggisReferenceNumber) {
-		final SubmissionListDTO response = this.submissionsService.getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORG_ID, ggisReferenceNumber);
+	public ResponseEntity<ApplicationListDTO> getSubmissionsByGgisRefNum(@PathVariable @NotNull String ggisReferenceNumber) {
+		final ApplicationListDTO response = this.submissionsService.getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORG_ID, ggisReferenceNumber);
 		return ResponseEntity.ok().body(response);
 	}
 

--- a/src/main/java/gov/cabinetoffice/api/controllers/SubmissionsController.java
+++ b/src/main/java/gov/cabinetoffice/api/controllers/SubmissionsController.java
@@ -22,19 +22,47 @@ import org.springframework.web.bind.annotation.RestController;
 @Tag(name = "Submissions", description = "API for handling applicants submissions")
 @RequiredArgsConstructor
 public class SubmissionsController {
+	private static final int FUNDING_ORG_ID = 1; // hard coding until we can take this value from pring security
 
 	private final SubmissionsService submissionsService;
 
-	@GetMapping("/{applicationId}")
+	@GetMapping
+		@ApiResponses(value = {
+			@ApiResponse(
+					responseCode = "200", description = "Submissions retrieved successfully.",
+					content = @Content(mediaType = "application/json",
+							schema = @Schema(implementation = Submission.class)
+					)
+			),
+			@ApiResponse(
+					responseCode = "404", description = "No submissions found for funding organisation",
+					content = @Content(mediaType = "application/json",
+							schema = @Schema(implementation = ErrorMessage.class)
+					)
+			)
+		})
+	public ResponseEntity<SubmissionListDTO> getSubmissions() {
+		final SubmissionListDTO response = this.submissionsService.getSubmissionsByFundingOrgId(FUNDING_ORG_ID);
+		return ResponseEntity.ok().body(response);
+	}
+
+	@GetMapping("/{ggisReferenceNumber}")
 	@ApiResponses(value = {
-			@ApiResponse(responseCode = "200", description = "Submissions retrieved successfully.",
+			@ApiResponse(
+					responseCode = "200", description = "Submissions retrieved successfully.",
 					content = @Content(mediaType = "application/json",
-							schema = @Schema(implementation = Submission.class))),
-			@ApiResponse(responseCode = "404", description = "No submissions found with given application id",
+							schema = @Schema(implementation = Submission.class)
+					)
+			),
+			@ApiResponse(
+					responseCode = "404", description = "No submissions found for funding organisation or GGIS ID",
 					content = @Content(mediaType = "application/json",
-							schema = @Schema(implementation = ErrorMessage.class))) })
-	public ResponseEntity<SubmissionListDTO> getSubmissionByApplicationId(@PathVariable @NotNull int applicationId) {
-		final SubmissionListDTO response = this.submissionsService.getSubmissionByApplicationId(applicationId);
+							schema = @Schema(implementation = ErrorMessage.class)
+					)
+			)
+	})
+	public ResponseEntity<SubmissionListDTO> getSubmissionsByGgisRefNum(@PathVariable @NotNull String ggisReferenceNumber) {
+		final SubmissionListDTO response = this.submissionsService.getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORG_ID, ggisReferenceNumber);
 		return ResponseEntity.ok().body(response);
 	}
 

--- a/src/main/java/gov/cabinetoffice/api/dtos/submission/ApplicationDto.java
+++ b/src/main/java/gov/cabinetoffice/api/dtos/submission/ApplicationDto.java
@@ -6,23 +6,22 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SubmissionDTO {
+public class ApplicationDto {
 
-	private UUID submissionId;
+    private String applicationFormName;
 
-	private String grantApplicantEmailAddress;
+    private String grantAdminEmailAddress;
 
-	private ZonedDateTime submittedTimeStamp;
+    private String ggisReferenceNumber;
 
-	private List<SubmissionSectionDTO> sections;
-
+    @Builder.Default
+    private List<SubmissionDTO> submissions = new ArrayList<>();
 }

--- a/src/main/java/gov/cabinetoffice/api/dtos/submission/ApplicationListDTO.java
+++ b/src/main/java/gov/cabinetoffice/api/dtos/submission/ApplicationListDTO.java
@@ -6,23 +6,15 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
-import java.time.ZonedDateTime;
+import java.util.ArrayList;
 import java.util.List;
-import java.util.UUID;
 
 @Data
 @NoArgsConstructor
 @AllArgsConstructor
 @Builder
 @JsonIgnoreProperties(ignoreUnknown = true)
-public class SubmissionDTO {
-
-	private UUID submissionId;
-
-	private String grantApplicantEmailAddress;
-
-	private ZonedDateTime submittedTimeStamp;
-
-	private List<SubmissionSectionDTO> sections;
-
+public class ApplicationListDTO {
+    private int numberOfResults;
+    private List<ApplicationDto> applications = new ArrayList<>();
 }

--- a/src/main/java/gov/cabinetoffice/api/dtos/submission/ApplicationListDTO.java
+++ b/src/main/java/gov/cabinetoffice/api/dtos/submission/ApplicationListDTO.java
@@ -16,5 +16,7 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class ApplicationListDTO {
     private int numberOfResults;
+
+    @Builder.Default
     private List<ApplicationDto> applications = new ArrayList<>();
 }

--- a/src/main/java/gov/cabinetoffice/api/dtos/submission/SubmissionListDTO.java
+++ b/src/main/java/gov/cabinetoffice/api/dtos/submission/SubmissionListDTO.java
@@ -6,6 +6,7 @@ import lombok.Builder;
 import lombok.Data;
 import lombok.NoArgsConstructor;
 
+import java.util.ArrayList;
 import java.util.List;
 
 @Data
@@ -15,6 +16,9 @@ import java.util.List;
 @JsonIgnoreProperties(ignoreUnknown = true)
 public class SubmissionListDTO {
 
-	private List<SubmissionDTO> submissions;
+	private int numberOfResults;
+
+	@Builder.Default
+	private List<SubmissionDTO> submissions = new ArrayList<>();
 
 }

--- a/src/main/java/gov/cabinetoffice/api/mappers/CustomSubmissionMapperImpl.java
+++ b/src/main/java/gov/cabinetoffice/api/mappers/CustomSubmissionMapperImpl.java
@@ -1,17 +1,17 @@
 package gov.cabinetoffice.api.mappers;
 
-import gov.cabinetoffice.api.entities.GrantAttachment;
-import gov.cabinetoffice.api.entities.Submission;
 import gov.cabinetoffice.api.config.S3ConfigProperties;
 import gov.cabinetoffice.api.dtos.submission.AddressDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionQuestionDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionSectionDTO;
+import gov.cabinetoffice.api.entities.GrantAttachment;
+import gov.cabinetoffice.api.entities.Submission;
 import gov.cabinetoffice.api.models.submission.SubmissionQuestion;
 import gov.cabinetoffice.api.models.submission.SubmissionSection;
 import gov.cabinetoffice.api.services.GrantAttachmentService;
 import gov.cabinetoffice.api.services.S3Service;
-import org.springframework.beans.factory.annotation.Autowired;
+import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
@@ -19,18 +19,15 @@ import java.time.LocalDate;
 import java.util.List;
 import java.util.UUID;
 
+@RequiredArgsConstructor
 @Component
 @Primary
 public class CustomSubmissionMapperImpl implements SubmissionMapper {
 
-	@Autowired
-	GrantAttachmentService grantAttachmentService;
-
-	@Autowired
-	S3Service s3Service;
-
-	@Autowired
-	S3ConfigProperties s3ConfigProperties;
+	public static final String AMAZON_AWS_URL = ".amazonaws.com/";
+	private final GrantAttachmentService grantAttachmentService;
+	private final S3Service s3Service;
+	private final S3ConfigProperties s3ConfigProperties;
 
 	@Override
 	public List<SubmissionSectionDTO> mapSections(List<SubmissionSection> sections) {
@@ -64,9 +61,8 @@ public class CustomSubmissionMapperImpl implements SubmissionMapper {
 		final UUID grantAttachmentId = submissionQuestion.getAttachmentId();
 		final GrantAttachment grantAttachment = grantAttachmentService.getGrantAttachmentById(grantAttachmentId);
 		final String bucketName = s3ConfigProperties.getSourceBucket();
-		final String objectKey = grantAttachment.getLocation().split(".amazonaws.com/")[1];
+		final String objectKey = grantAttachment.getLocation().split(AMAZON_AWS_URL)[1];
 		return s3Service.createPresignedURL(bucketName, objectKey);
-
 	}
 
 	@Override
@@ -84,6 +80,7 @@ public class CustomSubmissionMapperImpl implements SubmissionMapper {
 		if (submission == null) {
 			return null;
 		}
+
 		final List<SubmissionSection> sections = submissionDefinitionSections(submission);
 		return SubmissionDTO.builder()
 			.submissionId(submission.getId())
@@ -94,7 +91,6 @@ public class CustomSubmissionMapperImpl implements SubmissionMapper {
 			.submittedTimeStamp(submission.getSubmittedDate())
 			.sections(mapSections(sections))
 			.build();
-
 	}
 
 	@Override
@@ -111,24 +107,23 @@ public class CustomSubmissionMapperImpl implements SubmissionMapper {
 
 	}
 
-	String submissionApplicationApplicationName(Submission submission) {
+	public String submissionApplicationApplicationName(Submission submission) {
 		return (submission != null && submission.getApplication() != null)
 				? submission.getApplication().getApplicationName() : null;
 	}
 
-	String submissionSchemeEmail(Submission submission) {
+	public String submissionSchemeEmail(Submission submission) {
 		return (submission != null && submission.getScheme() != null) ? submission.getScheme().getEmail() : null;
 	}
 
-	String submissionSchemeGgisIdentifier(Submission submission) {
+	public String submissionSchemeGgisIdentifier(Submission submission) {
 		return (submission != null && submission.getScheme() != null) ? submission.getScheme().getGgisIdentifier()
 				: null;
 	}
 
-	List<SubmissionSection> submissionDefinitionSections(Submission submission) {
+	public List<SubmissionSection> submissionDefinitionSections(Submission submission) {
 		return (submission != null && submission.getDefinition() != null) ? submission.getDefinition().getSections()
 				: null;
-
 	}
 
 }

--- a/src/main/java/gov/cabinetoffice/api/mappers/CustomSubmissionMapperImpl.java
+++ b/src/main/java/gov/cabinetoffice/api/mappers/CustomSubmissionMapperImpl.java
@@ -1,22 +1,24 @@
 package gov.cabinetoffice.api.mappers;
 
 import gov.cabinetoffice.api.config.S3ConfigProperties;
-import gov.cabinetoffice.api.dtos.submission.AddressDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionQuestionDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionSectionDTO;
+import gov.cabinetoffice.api.dtos.submission.*;
+import gov.cabinetoffice.api.entities.ApplicationFormEntity;
 import gov.cabinetoffice.api.entities.GrantAttachment;
 import gov.cabinetoffice.api.entities.Submission;
+import gov.cabinetoffice.api.exceptions.SubmissionNotFoundException;
 import gov.cabinetoffice.api.models.submission.SubmissionQuestion;
 import gov.cabinetoffice.api.models.submission.SubmissionSection;
 import gov.cabinetoffice.api.services.GrantAttachmentService;
 import gov.cabinetoffice.api.services.S3Service;
 import lombok.RequiredArgsConstructor;
+import org.javatuples.Pair;
 import org.springframework.context.annotation.Primary;
 import org.springframework.stereotype.Component;
 
 import java.time.LocalDate;
+import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.UUID;
 
 @RequiredArgsConstructor
@@ -75,6 +77,50 @@ public class CustomSubmissionMapperImpl implements SubmissionMapper {
 		return SubmissionMapper.super.buildAddress(multiResponse);
 	}
 
+	// TODO - look into whether this is horrendously inefficient. Potentially more performant to do all this looping at query level.
+	@Override
+	public ApplicationListDTO submissionListToApplicationListDto(final List<Submission> submissions) {
+		final List<ApplicationDto> applicationSubmissions = Optional.ofNullable(submissions)
+				.orElse(Collections.emptyList())
+				.stream()
+				.map(Submission::getApplication)
+				.distinct()
+				.toList()
+				.stream()
+				.map(form -> groupSubmissionsByApplicationForm(form, submissions))
+				.toList();
+
+		return ApplicationListDTO.builder()
+				.numberOfResults(applicationSubmissions.size())
+				.applications(applicationSubmissions)
+				.build();
+	}
+
+	private ApplicationDto groupSubmissionsByApplicationForm(final ApplicationFormEntity form, final List<Submission> submissions) {
+		final Pair<String, String> applicationDetails = submissions.stream()
+				.filter(submission -> form.getGrantApplicationId().equals(submission.getApplication().getGrantApplicationId()))
+				.findFirst()
+				.map(submission ->
+						Pair.with(
+								submission.getScheme().getEmail(),
+								submission.getScheme().getGgisIdentifier()
+						)
+				)
+				.orElseThrow(() -> new SubmissionNotFoundException("No submissions found"));
+
+		final List<SubmissionDTO> submissionDtos = submissions.stream()
+				.filter(submission -> form.getGrantApplicationId().equals(submission.getApplication().getGrantApplicationId()))
+				.map(this::submissionToSubmissionDto)
+				.toList();
+
+		return ApplicationDto.builder()
+				.grantAdminEmailAddress(applicationDetails.getValue0())
+				.ggisReferenceNumber(applicationDetails.getValue1())
+				.applicationFormName(form.getApplicationName())
+				.submissions(submissionDtos)
+				.build();
+	}
+
 	@Override
 	public SubmissionDTO submissionToSubmissionDto(Submission submission) {
 		if (submission == null) {
@@ -84,10 +130,7 @@ public class CustomSubmissionMapperImpl implements SubmissionMapper {
 		final List<SubmissionSection> sections = submissionDefinitionSections(submission);
 		return SubmissionDTO.builder()
 			.submissionId(submission.getId())
-			.applicationFormName(submissionApplicationApplicationName(submission))
-			.grantAdminEmailAddress(submissionSchemeEmail(submission))
 			.grantApplicantEmailAddress(submissionSchemeEmail(submission))
-			.ggisReferenceNumber(submissionSchemeGgisIdentifier(submission))
 			.submittedTimeStamp(submission.getSubmittedDate())
 			.sections(mapSections(sections))
 			.build();

--- a/src/main/java/gov/cabinetoffice/api/mappers/SubmissionMapper.java
+++ b/src/main/java/gov/cabinetoffice/api/mappers/SubmissionMapper.java
@@ -76,7 +76,7 @@ public interface SubmissionMapper {
 			case AddressInput -> buildAddress(multiResponse);
 			case Date -> buildDate(multiResponse);
 			case SingleFileUpload -> buildUploadResponse(submissionQuestion);
-			default -> ""; // TODO do we want this to be null or an empty string?
+			default -> "";
 		};
 	}
 

--- a/src/main/java/gov/cabinetoffice/api/mappers/SubmissionMapper.java
+++ b/src/main/java/gov/cabinetoffice/api/mappers/SubmissionMapper.java
@@ -1,10 +1,7 @@
 package gov.cabinetoffice.api.mappers;
 
+import gov.cabinetoffice.api.dtos.submission.*;
 import gov.cabinetoffice.api.entities.Submission;
-import gov.cabinetoffice.api.dtos.submission.AddressDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionQuestionDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionSectionDTO;
 import gov.cabinetoffice.api.models.submission.SubmissionQuestion;
 import gov.cabinetoffice.api.models.submission.SubmissionSection;
 import org.mapstruct.Mapper;
@@ -20,11 +17,7 @@ import static java.lang.Integer.parseInt;
 public interface SubmissionMapper {
 
 	@Mapping(source = "id", target = "submissionId")
-	@Mapping(source = "application.applicationName", target = "applicationFormName")
-	// TODO is adminEmail the same as scheme.email? Don't store grantApplicant email
-	@Mapping(source = "scheme.email", target = "grantAdminEmailAddress")
-	@Mapping(source = "scheme.email", target = "grantApplicantEmailAddress")
-	@Mapping(source = "scheme.ggisIdentifier", target = "ggisReferenceNumber")
+	@Mapping(source = "scheme.email", target = "grantApplicantEmailAddress") //TODO fetch the applicant email from the database after one login work completes - this is not the correct value
 	@Mapping(source = "submittedDate", target = "submittedTimeStamp")
 	@Mapping(source = "definition.sections", target = "sections", qualifiedByName = "mapSections")
 	SubmissionDTO submissionToSubmissionDto(Submission submission);
@@ -100,4 +93,5 @@ public interface SubmissionMapper {
 			.build();
 	}
 
+	default ApplicationListDTO submissionListToApplicationListDto(final List<Submission> submissions) {return ApplicationListDTO.builder().build();}
 }

--- a/src/main/java/gov/cabinetoffice/api/repositories/SubmissionRepository.java
+++ b/src/main/java/gov/cabinetoffice/api/repositories/SubmissionRepository.java
@@ -12,4 +12,7 @@ public interface SubmissionRepository extends JpaRepository<Submission, UUID> {
 
 	List<Submission> findByApplicationGrantApplicationId(Integer applicationId);
 
+	List<Submission> findBySchemeFunderIdAndSchemeGgisIdentifier(int funderId, String ggisIdentifier);
+
+	List<Submission> findBySchemeFunderId(int fundingOrgId);
 }

--- a/src/main/java/gov/cabinetoffice/api/services/S3Service.java
+++ b/src/main/java/gov/cabinetoffice/api/services/S3Service.java
@@ -10,20 +10,16 @@ import java.time.Duration;
 @RequiredArgsConstructor
 public class S3Service {
 
-	// TODO decide on duration
 	public static final int URL_DURATION = 15;
 
 	private final S3Presigner presigner;
 
 	public String createPresignedURL(String bucketName, String objectKey) {
-
-		// Create a GetObjectPresignRequest to specify the signature duration
 		final GetObjectPresignRequest getObjectPresignRequest = GetObjectPresignRequest.builder()
 			.signatureDuration(Duration.ofSeconds(URL_DURATION))
 			.getObjectRequest(getObjectRequest -> getObjectRequest.bucket(bucketName).key(objectKey))
 			.build();
 
-		// Generate the presigned request and return the Url
 		return presigner.presignGetObject(getObjectPresignRequest).url().toString();
 	}
 

--- a/src/main/java/gov/cabinetoffice/api/services/SubmissionsService.java
+++ b/src/main/java/gov/cabinetoffice/api/services/SubmissionsService.java
@@ -1,7 +1,7 @@
 package gov.cabinetoffice.api.services;
 
-import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionListDTO;
+import gov.cabinetoffice.api.entities.Submission;
 import gov.cabinetoffice.api.mappers.SubmissionMapper;
 import gov.cabinetoffice.api.exceptions.SubmissionNotFoundException;
 import gov.cabinetoffice.api.repositories.SubmissionRepository;
@@ -16,22 +16,31 @@ import java.util.stream.Collectors;
 public class SubmissionsService {
 
 	private final SubmissionRepository submissionRepository;
-
 	private final SubmissionMapper submissionMapper;
 
-	public SubmissionListDTO getSubmissionByApplicationId(int applicationId) {
-
-		final List<SubmissionDTO> submissionDTOS = submissionRepository
-			.findByApplicationGrantApplicationId(applicationId)
-			.stream()
-			.map(submissionMapper::submissionToSubmissionDto)
-			.collect(Collectors.collectingAndThen(Collectors.toList(), result -> {
-				if (result.isEmpty())
-					throw new SubmissionNotFoundException("No submissions found with application id " + applicationId);
-				return result;
-			}));
-
-		return SubmissionListDTO.builder().submissions(submissionDTOS).build();
+	public SubmissionListDTO getSubmissionsByFundingOrgIdAndGgisReferenceNum(int fundingOrgId, String ggisReferenceNumber) {
+		final List<Submission> submissions = submissionRepository.findBySchemeFunderIdAndSchemeGgisIdentifier(fundingOrgId, ggisReferenceNumber);
+		return mapSubmissionsToSubmissionListDto(submissions);
 	}
 
+	public SubmissionListDTO getSubmissionsByFundingOrgId(int fundingOrgId) {
+		final List<Submission> submissions = submissionRepository.findBySchemeFunderId(fundingOrgId);
+		return mapSubmissionsToSubmissionListDto(submissions);
+	}
+
+	private SubmissionListDTO mapSubmissionsToSubmissionListDto(final List<Submission> submissions) {
+		return SubmissionListDTO
+				.builder()
+				.numberOfResults(submissions.size())
+				.submissions(
+						submissions
+						.stream()
+						.map(submissionMapper::submissionToSubmissionDto)
+						.collect(Collectors.collectingAndThen(Collectors.toList(), result -> {
+							if (result.isEmpty())
+								throw new SubmissionNotFoundException("No submissions found");
+							return result;
+						})))
+				.build();
+	}
 }

--- a/src/main/java/gov/cabinetoffice/api/services/SubmissionsService.java
+++ b/src/main/java/gov/cabinetoffice/api/services/SubmissionsService.java
@@ -1,15 +1,13 @@
 package gov.cabinetoffice.api.services;
 
-import gov.cabinetoffice.api.dtos.submission.SubmissionListDTO;
+import gov.cabinetoffice.api.dtos.submission.ApplicationListDTO;
 import gov.cabinetoffice.api.entities.Submission;
 import gov.cabinetoffice.api.mappers.SubmissionMapper;
-import gov.cabinetoffice.api.exceptions.SubmissionNotFoundException;
 import gov.cabinetoffice.api.repositories.SubmissionRepository;
 import lombok.RequiredArgsConstructor;
 import org.springframework.stereotype.Service;
 
 import java.util.List;
-import java.util.stream.Collectors;
 
 @Service
 @RequiredArgsConstructor
@@ -18,29 +16,13 @@ public class SubmissionsService {
 	private final SubmissionRepository submissionRepository;
 	private final SubmissionMapper submissionMapper;
 
-	public SubmissionListDTO getSubmissionsByFundingOrgIdAndGgisReferenceNum(int fundingOrgId, String ggisReferenceNumber) {
+	public ApplicationListDTO getSubmissionsByFundingOrgIdAndGgisReferenceNum(int fundingOrgId, String ggisReferenceNumber) {
 		final List<Submission> submissions = submissionRepository.findBySchemeFunderIdAndSchemeGgisIdentifier(fundingOrgId, ggisReferenceNumber);
-		return mapSubmissionsToSubmissionListDto(submissions);
+		return submissionMapper.submissionListToApplicationListDto(submissions);
 	}
 
-	public SubmissionListDTO getSubmissionsByFundingOrgId(int fundingOrgId) {
+	public ApplicationListDTO getSubmissionsByFundingOrgId(int fundingOrgId) {
 		final List<Submission> submissions = submissionRepository.findBySchemeFunderId(fundingOrgId);
-		return mapSubmissionsToSubmissionListDto(submissions);
-	}
-
-	private SubmissionListDTO mapSubmissionsToSubmissionListDto(final List<Submission> submissions) {
-		return SubmissionListDTO
-				.builder()
-				.numberOfResults(submissions.size())
-				.submissions(
-						submissions
-						.stream()
-						.map(submissionMapper::submissionToSubmissionDto)
-						.collect(Collectors.collectingAndThen(Collectors.toList(), result -> {
-							if (result.isEmpty())
-								throw new SubmissionNotFoundException("No submissions found");
-							return result;
-						})))
-				.build();
+		return submissionMapper.submissionListToApplicationListDto(submissions);
 	}
 }

--- a/src/test/java/gov/cabinetoffice/api/controllers/SubmissionsControllerTest.java
+++ b/src/test/java/gov/cabinetoffice/api/controllers/SubmissionsControllerTest.java
@@ -1,23 +1,22 @@
 package gov.cabinetoffice.api.controllers;
 
-import gov.cabinetoffice.api.dtos.submission.AddressDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
+import gov.cabinetoffice.api.dtos.submission.*;
 import gov.cabinetoffice.api.entities.ApplicationFormEntity;
 import gov.cabinetoffice.api.entities.SchemeEntity;
 import gov.cabinetoffice.api.enums.ResponseTypeEnum;
+import gov.cabinetoffice.api.exceptions.SubmissionNotFoundException;
 import gov.cabinetoffice.api.models.application.ApplicationDefinition;
 import gov.cabinetoffice.api.models.submission.SubmissionQuestion;
 import gov.cabinetoffice.api.models.submission.SubmissionQuestionValidation;
-import gov.cabinetoffice.api.dtos.submission.SubmissionListDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionQuestionDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionSectionDTO;
-import gov.cabinetoffice.api.exceptions.SubmissionNotFoundException;
 import gov.cabinetoffice.api.services.SubmissionsService;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import static org.assertj.core.api.AssertionsForClassTypes.assertThatExceptionOfType;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
@@ -26,11 +25,6 @@ import java.time.Instant;
 import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.junit.jupiter.api.Assertions.assertThrows;
-import static org.mockito.Mockito.verify;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class SubmissionsControllerTest {
@@ -176,9 +170,6 @@ class SubmissionsControllerTest {
 
 	final SubmissionDTO submissionDTO = SubmissionDTO.builder()
 		.submissionId(SUBMISSION_ID)
-		.applicationFormName(application.getApplicationName())
-		.ggisReferenceNumber(scheme.getGgisIdentifier())
-		.grantAdminEmailAddress(scheme.getEmail())
 		.submittedTimeStamp(zonedDateTime)
 		.grantApplicantEmailAddress(scheme.getEmail())
 		.sections(List.of(submissionSectionDTO1, submissionSectionDTO2))
@@ -203,14 +194,16 @@ class SubmissionsControllerTest {
 	@Test
 	void getSubmissions_ReturnsExpectedSubmissions() {
 
-		when(submissionService.getSubmissionsByFundingOrgId(FUNDING_ORGANISATION_ID))
-				.thenReturn(submissionsDTO);
+		final ApplicationListDTO applications = ApplicationListDTO.builder().build();
 
-		final ResponseEntity<SubmissionListDTO> methodResponse = controllerUnderTest.getSubmissions();
+		when(submissionService.getSubmissionsByFundingOrgId(FUNDING_ORGANISATION_ID))
+				.thenReturn(applications);
+
+		final ResponseEntity<ApplicationListDTO> methodResponse = controllerUnderTest.getSubmissions();
 
 		verify(submissionService).getSubmissionsByFundingOrgId(FUNDING_ORGANISATION_ID);
 		assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(methodResponse.getBody()).isEqualTo(submissionsDTO);
+		assertThat(methodResponse.getBody()).isEqualTo(applications);
 	}
 
 	@Test
@@ -227,14 +220,16 @@ class SubmissionsControllerTest {
 	@Test
 	void getSubmissionsByGgisRefNum_ReturnsExpectedSubmissions() {
 
-		when(submissionService.getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORGANISATION_ID, GGIS_REFERENCE_NUMBER))
-				.thenReturn(submissionsDTO);
+		final ApplicationListDTO applications = ApplicationListDTO.builder().build();
 
-		final ResponseEntity<SubmissionListDTO> methodResponse = controllerUnderTest.getSubmissionsByGgisRefNum(GGIS_REFERENCE_NUMBER);
+		when(submissionService.getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORGANISATION_ID, GGIS_REFERENCE_NUMBER))
+				.thenReturn(applications);
+
+		final ResponseEntity<ApplicationListDTO> methodResponse = controllerUnderTest.getSubmissionsByGgisRefNum(GGIS_REFERENCE_NUMBER);
 
 		verify(submissionService).getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORGANISATION_ID, GGIS_REFERENCE_NUMBER);
 		assertThat(methodResponse.getStatusCode()).isEqualTo(HttpStatus.OK);
-		assertThat(methodResponse.getBody()).isEqualTo(submissionsDTO);
+		assertThat(methodResponse.getBody()).isEqualTo(applications);
 	}
 
 	@Test

--- a/src/test/java/gov/cabinetoffice/api/mappers/CustomSubmissionMapperImplTest.java
+++ b/src/test/java/gov/cabinetoffice/api/mappers/CustomSubmissionMapperImplTest.java
@@ -1,279 +1,44 @@
 package gov.cabinetoffice.api.mappers;
 
 import gov.cabinetoffice.api.config.S3ConfigProperties;
-import gov.cabinetoffice.api.dtos.submission.AddressDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
-import gov.cabinetoffice.api.dtos.submission.SubmissionQuestionDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionSectionDTO;
-import gov.cabinetoffice.api.enums.ResponseTypeEnum;
-import gov.cabinetoffice.api.enums.SubmissionSectionStatus;
-import gov.cabinetoffice.api.enums.SubmissionStatus;
-import gov.cabinetoffice.api.models.application.ApplicationDefinition;
-import gov.cabinetoffice.api.models.submission.SubmissionDefinition;
-import gov.cabinetoffice.api.models.submission.SubmissionQuestion;
-import gov.cabinetoffice.api.models.submission.SubmissionQuestionValidation;
-import gov.cabinetoffice.api.models.submission.SubmissionSection;
-import gov.cabinetoffice.api.entities.ApplicationFormEntity;
-import gov.cabinetoffice.api.entities.GrantApplicant;
-import gov.cabinetoffice.api.entities.GrantApplicantOrganisationProfile;
 import gov.cabinetoffice.api.entities.GrantAttachment;
-import gov.cabinetoffice.api.entities.SchemeEntity;
 import gov.cabinetoffice.api.entities.Submission;
+import gov.cabinetoffice.api.models.submission.SubmissionQuestion;
+import gov.cabinetoffice.api.models.submission.SubmissionSection;
 import gov.cabinetoffice.api.services.GrantAttachmentService;
 import gov.cabinetoffice.api.services.S3Service;
+import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
+import static org.mockito.ArgumentMatchers.any;
 import org.mockito.InjectMocks;
 import org.mockito.Mock;
+import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 
-import java.time.Instant;
-import java.time.LocalDateTime;
-import java.time.ZonedDateTime;
 import java.util.List;
 import java.util.UUID;
-
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
-import static org.mockito.ArgumentMatchers.any;
-import static org.mockito.Mockito.when;
 
 @ExtendWith(MockitoExtension.class)
 class CustomSubmissionMapperImplTest {
 
 	@Mock
-    S3ConfigProperties s3ConfigProperties;
+	private GrantAttachmentService grantAttachmentService;
 
 	@Mock
-    S3Service s3Service;
+	private S3Service s3Service;
 
-	@InjectMocks
-	CustomSubmissionMapperImpl customSubmissionMapper;
-
-	private static final int APPLICATION_ID = 1;
-
-	private final UUID GRANT_ATTACHMENT_ID = UUID.randomUUID();
-
-	final LocalDateTime timestamp = LocalDateTime.now();
-
-	final ZonedDateTime zonedDateTime = ZonedDateTime.now();
-
-	final Instant instant = Instant.now();
-
-	final String QUESTION_ID_1 = "APPLICANT_ORG_NAME";
-
-	final String QUESTION_ID_2 = "APPLICANT_ORG_ADDRESS";
-
-	final String QUESTION_ID_3 = "APPLICANT_ORG_COMPANIES_HOUSE";
-
-	final String QUESTION_ID_4 = "CUSTOM_INPUT_1";
-
-	final String QUESTION_ID_5 = "FILE_UPLOAD_1";
-
-	final String SECTION_ID_1 = "ELIGIBILITY";
-
-	final String SECTION_ID_2 = "CUSTOM_SECTION_1";
-
-	final String SECTION_TITLE_1 = "Eligibility";
-
-	final String SECTION_TITLE_2 = "Project Status";
-
-	final SchemeEntity scheme = SchemeEntity.builder()
-		.id(1)
-		.version(1)
-		.funderId(1)
-		.lastUpdated(instant)
-		.email("test@and.digital")
-		.name("Test Scheme")
-		.ggisIdentifier("Test GGIS Identifier")
-		.build();
-
-	final ApplicationFormEntity application = ApplicationFormEntity.builder()
-		.grantApplicationId(APPLICATION_ID)
-		.applicationName("Test Application")
-		.created(instant)
-		.lastUpdated(instant)
-		.definition(new ApplicationDefinition())
-		.grantSchemeId(scheme.getId())
-		.version(1)
-		.lastUpdateBy(1)
-		.build();
-
-	final SubmissionQuestion question1 = SubmissionQuestion.builder()
-		.questionId(QUESTION_ID_1)
-		.profileField("ORG_NAME")
-		.fieldTitle("Enter the name of your organisation")
-		.hintText(
-				"This is the official name of your organisation. It could be the name that is registered with Companies House or the Charities Commission")
-		.responseType(ResponseTypeEnum.ShortAnswer)
-		.response("organisationName")
-		.validation(SubmissionQuestionValidation.builder().mandatory(true).minLength(2).maxLength(250).build())
-		.build();
-
-	final SubmissionQuestionDTO questionDTO1 = SubmissionQuestionDTO.builder()
-		.questionId(question1.getQuestionId())
-		.questionTitle(question1.getFieldTitle())
-		.questionResponse(question1.getResponse())
-		.build();
-
-	final String[] address = { "addressLine1", "addressLine2", "town", "county", "postcode" };
-
-	final SubmissionQuestion question2 = SubmissionQuestion.builder()
-		.questionId(QUESTION_ID_2)
-		.profileField("ORG_ADDRESS")
-		.fieldTitle("Enter your organisation's address")
-		.responseType(ResponseTypeEnum.AddressInput)
-		.multiResponse(address)
-		.validation(SubmissionQuestionValidation.builder().mandatory(true).build())
-		.build();
-
-	final SubmissionQuestion question3 = SubmissionQuestion.builder()
-		.questionId(QUESTION_ID_3)
-		.profileField("ORG_COMPANIES_HOUSE")
-		.fieldTitle("Does your organisation have a Companies House number?")
-		.hintText(
-				"Funding organisation might use this to identify your organisation when you apply for a grant. It might also be used to check your organisation is legitimate.")
-		.responseType(ResponseTypeEnum.YesNo)
-		.response("yes")
-		.validation(SubmissionQuestionValidation.builder().minLength(5).maxLength(100).build())
-		.build();
-
-	final SubmissionSection section1 = SubmissionSection.builder()
-		.sectionId(SECTION_ID_1)
-		.sectionTitle(SECTION_TITLE_1)
-		.sectionStatus(SubmissionSectionStatus.IN_PROGRESS)
-		.questions(List.of(question1, question2, question3))
-		.build();
-
-	final SubmissionQuestionDTO questionDTO3 = SubmissionQuestionDTO.builder()
-		.questionId(question3.getQuestionId())
-		.questionTitle(question3.getFieldTitle())
-		.questionResponse(question3.getResponse())
-		.build();
-
-	final SubmissionQuestion question4 = SubmissionQuestion.builder()
-		.questionId(QUESTION_ID_4)
-		.fieldTitle(
-				"Description of the project, please include information regarding public accessibility (see GOV.UK guidance for a definition of public access) to the newly planted trees")
-		.hintText("Optional additional helptext")
-		.responseType(ResponseTypeEnum.LongAnswer)
-		.validation(SubmissionQuestionValidation.builder()
-			.mandatory(true)
-			.minLength(100)
-			.maxLength(2000)
-			.minWords(50)
-			.maxWords(400)
-			.build())
-		.response("description of the project")
-		.build();
-
-	final SubmissionSection section2 = SubmissionSection.builder()
-		.sectionId(SECTION_ID_2)
-		.sectionTitle(SECTION_TITLE_2)
-		.sectionStatus(SubmissionSectionStatus.IN_PROGRESS)
-		.questions(List.of(question4))
-		.build();
-
-	final SubmissionDefinition definition = SubmissionDefinition.builder()
-		.sections(List.of(section1, section2))
-		.build();
-
-	final SubmissionQuestionDTO questionDTO4 = SubmissionQuestionDTO.builder()
-		.questionId(question4.getQuestionId())
-		.questionTitle(question4.getFieldTitle())
-		.questionResponse(question4.getResponse())
-		.build();
-
-	final SubmissionSectionDTO submissionSectionDTO2 = SubmissionSectionDTO.builder()
-		.sectionId(SECTION_ID_2)
-		.sectionTitle(SECTION_TITLE_2)
-		.questions(List.of(questionDTO4))
-		.build();
-
-	final AddressDTO addressDTO = AddressDTO.builder()
-		.addressLine1(address[0])
-		.addressLine2(address[1])
-		.town(address[2])
-		.county(address[3])
-		.postcode(address[4])
-		.build();
-
-	final SubmissionQuestionDTO questionDTO2 = SubmissionQuestionDTO.builder()
-		.questionId(question2.getQuestionId())
-		.questionTitle(question2.getFieldTitle())
-		.questionResponse(addressDTO)
-		.build();
-
-	final SubmissionSectionDTO submissionSectionDTO1 = SubmissionSectionDTO.builder()
-		.sectionId(SECTION_ID_1)
-		.sectionTitle(SECTION_TITLE_1)
-		.questions(List.of(questionDTO1, questionDTO2, questionDTO3))
-		.build();
-
-	final String[] date = { "01", "12", "1987" };
-
-	private final long APPLICANT_ID = 1;
-
-	private final long PROFILE_ID = 1;
-
-	final GrantApplicantOrganisationProfile grantApplicantOrganisationProfile = GrantApplicantOrganisationProfile
-		.builder()
-		.id(PROFILE_ID)
-		.legalName("AND Digital")
-		.charityCommissionNumber("45")
-		.companiesHouseNumber("000010")
-		.addressLine1("AND Digital")
-		.addressLine2("9 George Square")
-		.town("Glasgow")
-		.postcode("G2 1QQ")
-		.county("Renfrewshire")
-		.build();
-
-	private final UUID APPLICANT_USER_ID = UUID.fromString("75ab5fbd-0682-4d3d-a467-01c7a447f07c");
-
-	final GrantApplicant grantApplicant = GrantApplicant.builder()
-		.id(APPLICANT_ID)
-		.userId(APPLICANT_USER_ID)
-		.organisationProfile(grantApplicantOrganisationProfile)
-		.build();
-
-	private final UUID SUBMISSION_ID = UUID.fromString("1c2eabf0-b33c-433a-b00f-e73d8efca929");
-
-	final Submission submission = Submission.builder()
-		.id(SUBMISSION_ID)
-		.applicant(grantApplicant)
-		.scheme(scheme)
-		.application(application)
-		.version(1)
-		.created(timestamp)
-		.createdBy(grantApplicant)
-		.lastUpdated(timestamp)
-		.lastUpdatedBy(grantApplicant)
-		.applicationName("Test Submission")
-		.status(SubmissionStatus.IN_PROGRESS)
-		.definition(definition)
-		.submittedDate(zonedDateTime)
-		.build();
-
-	final SubmissionDTO submissionDTO = SubmissionDTO.builder()
-		.submissionId(SUBMISSION_ID)
-		.applicationFormName(application.getApplicationName())
-		.ggisReferenceNumber(scheme.getGgisIdentifier())
-		.grantAdminEmailAddress(scheme.getEmail())
-		.submittedTimeStamp(zonedDateTime)
-		.grantApplicantEmailAddress(scheme.getEmail())
-		.sections(List.of(submissionSectionDTO1, submissionSectionDTO2))
-		.build();
+	@Mock
+	private S3ConfigProperties s3ConfigProperties;
 
 	@InjectMocks
 	private CustomSubmissionMapperImpl customSubmissionMapperImpl;
 
-	@Mock
-	GrantAttachmentService grantAttachmentService;
-
-	// didn't test the other methods because they are tested in SubmissionMapperTest
-
 	@Test
 	void buildUploadResponse() {
+		final UUID GRANT_ATTACHMENT_ID = UUID.randomUUID();
 		final String expectedResult = "presignedUrl";
 
 		final SubmissionQuestion submissionQuestion = SubmissionQuestion.builder()
@@ -294,8 +59,12 @@ class CustomSubmissionMapperImplTest {
 
 	@Test
 	void submissionToSubmissionDto() {
+		final Submission submission = SubmissionMapperTestData.getSubmission();
+		final SubmissionDTO submissionDto = SubmissionMapperTestData.getSubmissionDto();
+
 		final SubmissionDTO result = customSubmissionMapperImpl.submissionToSubmissionDto(submission);
-		assertThat(result).isEqualTo(submissionDTO);
+
+		assertThat(result).isEqualTo(submissionDto);
 	}
 
 	@Test
@@ -306,9 +75,13 @@ class CustomSubmissionMapperImplTest {
 
 	@Test
 	void submissionSectionToSubmissionSectionDto() {
+		final SubmissionSection section = SubmissionMapperTestData.getSubmissionSection();
+		final SubmissionSectionDTO sectionDTO = SubmissionMapperTestData.getSubmissionSectionDto();
+
 		final SubmissionSectionDTO result = customSubmissionMapperImpl
-			.submissionSectionToSubmissionSectionDto(section1);
-		assertThat(result).isEqualTo(submissionSectionDTO1);
+			.submissionSectionToSubmissionSectionDto(section);
+
+		assertThat(result).isEqualTo(sectionDTO);
 	}
 
 	@Test
@@ -319,7 +92,10 @@ class CustomSubmissionMapperImplTest {
 
 	@Test
 	void submissionApplicationApplicationName() {
+		final Submission submission = SubmissionMapperTestData.getSubmission();
+
 		final String result = customSubmissionMapperImpl.submissionApplicationApplicationName(submission);
+
 		assertThat(result).isEqualTo(submission.getApplication().getApplicationName());
 	}
 
@@ -338,7 +114,10 @@ class CustomSubmissionMapperImplTest {
 
 	@Test
 	void submissionSchemeEmail() {
+		final Submission submission = SubmissionMapperTestData.getSubmission();
+
 		final String result = customSubmissionMapperImpl.submissionSchemeEmail(submission);
+
 		assertThat(result).isEqualTo(submission.getScheme().getEmail());
 	}
 
@@ -357,7 +136,10 @@ class CustomSubmissionMapperImplTest {
 
 	@Test
 	void submissionSchemeGgisIdentifier() {
+		final Submission submission = SubmissionMapperTestData.getSubmission();
+
 		final String result = customSubmissionMapperImpl.submissionSchemeGgisIdentifier(submission);
+
 		assertThat(result).isEqualTo(submission.getScheme().getGgisIdentifier());
 	}
 
@@ -376,7 +158,10 @@ class CustomSubmissionMapperImplTest {
 
 	@Test
 	void submissionDefinitionSections() {
+		final Submission submission = SubmissionMapperTestData.getSubmission();
+
 		final List<SubmissionSection> result = customSubmissionMapperImpl.submissionDefinitionSections(submission);
+
 		assertThat(result).isEqualTo(submission.getDefinition().getSections());
 	}
 

--- a/src/test/java/gov/cabinetoffice/api/mappers/CustomSubmissionMapperImplTest.java
+++ b/src/test/java/gov/cabinetoffice/api/mappers/CustomSubmissionMapperImplTest.java
@@ -1,15 +1,20 @@
 package gov.cabinetoffice.api.mappers;
 
 import gov.cabinetoffice.api.config.S3ConfigProperties;
+import gov.cabinetoffice.api.dtos.submission.ApplicationDto;
+import gov.cabinetoffice.api.dtos.submission.ApplicationListDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionSectionDTO;
+import gov.cabinetoffice.api.entities.ApplicationFormEntity;
 import gov.cabinetoffice.api.entities.GrantAttachment;
+import gov.cabinetoffice.api.entities.SchemeEntity;
 import gov.cabinetoffice.api.entities.Submission;
+import gov.cabinetoffice.api.models.submission.SubmissionDefinition;
 import gov.cabinetoffice.api.models.submission.SubmissionQuestion;
 import gov.cabinetoffice.api.models.submission.SubmissionSection;
 import gov.cabinetoffice.api.services.GrantAttachmentService;
 import gov.cabinetoffice.api.services.S3Service;
-import static org.assertj.core.api.AssertionsForClassTypes.assertThat;
+import static org.assertj.core.api.Assertions.assertThat;
 import org.junit.jupiter.api.Test;
 import org.junit.jupiter.api.extension.ExtendWith;
 import static org.mockito.ArgumentMatchers.any;
@@ -18,6 +23,7 @@ import org.mockito.Mock;
 import static org.mockito.Mockito.when;
 import org.mockito.junit.jupiter.MockitoExtension;
 
+import java.util.Collections;
 import java.util.List;
 import java.util.UUID;
 
@@ -176,6 +182,97 @@ class CustomSubmissionMapperImplTest {
 		final Submission submission = Submission.builder().definition(null).build();
 		final List<SubmissionSection> result = customSubmissionMapperImpl.submissionDefinitionSections(submission);
 		assertThat(result).isNull();
+	}
+
+	@Test
+	void submissionListToApplicationListDto_HandlesEmptyList() {
+		final List<Submission> submissions = Collections.emptyList();
+
+		final ApplicationListDTO applications = customSubmissionMapperImpl.submissionListToApplicationListDto(submissions);
+
+		assertThat(applications.getApplications()).isEmpty();
+		assertThat(applications.getNumberOfResults()).isZero();
+	}
+
+	@Test
+	void submissionListToApplicationListDto_HandlesNullList() {
+		final List<Submission> submissions = null;
+
+		final ApplicationListDTO applications = customSubmissionMapperImpl.submissionListToApplicationListDto(submissions);
+
+		assertThat(applications.getApplications()).isEmpty();
+		assertThat(applications.getNumberOfResults()).isZero();
+	}
+
+	@Test
+	void submissionListToApplicationListDto_ReturnsExpectedResult() {
+
+		// build a submission for one application form
+		final ApplicationFormEntity application = ApplicationFormEntity.builder()
+				.grantApplicationId(1)
+				.applicationName("Woodland services grant")
+				.build();
+
+		final SchemeEntity scheme = SchemeEntity.builder()
+				.ggisIdentifier("WSG-001")
+				.email("gavin.cook@and.digital")
+				.build();
+
+		final UUID submissionId1 = UUID.randomUUID();
+		final Submission submission = Submission.builder()
+				.id(submissionId1)
+				.application(application)
+				.scheme(scheme)
+				.definition(
+						SubmissionDefinition
+						.builder()
+						.sections(Collections.emptyList())
+						.build()
+				)
+				.build();
+
+		// build a second submission for a different application form
+		final ApplicationFormEntity application2 = ApplicationFormEntity.builder()
+				.grantApplicationId(2)
+				.applicationName("Suburban services grant")
+				.build();
+
+		final SchemeEntity scheme2 = SchemeEntity.builder()
+				.ggisIdentifier("WSG-001")
+				.email("gavin.cook@and.digital")
+				.build();
+
+		final UUID submissionId2 = UUID.randomUUID();
+		final Submission submission2 = Submission.builder()
+				.id(submissionId2)
+				.application(application2)
+				.scheme(scheme2)
+				.definition(
+						SubmissionDefinition
+								.builder()
+								.sections(Collections.emptyList())
+								.build()
+				)
+				.build();
+
+		final List<Submission> submissions = List.of(submission, submission2);
+
+		// with a bit of luck, we'll have two Application DTOs here
+		final ApplicationListDTO methodResponse = customSubmissionMapperImpl.submissionListToApplicationListDto(submissions);
+
+		assertThat(methodResponse.getNumberOfResults()).isEqualTo(2);
+
+		final ApplicationDto applicationDto1 = methodResponse.getApplications().get(0);
+		assertThat(applicationDto1.getApplicationFormName()).isEqualTo(application.getApplicationName());
+		assertThat(applicationDto1.getGgisReferenceNumber()).isEqualTo(scheme.getGgisIdentifier());
+		assertThat(applicationDto1.getSubmissions()).hasSize(1);
+		assertThat(applicationDto1.getSubmissions().get(0).getSubmissionId()).isEqualTo(submissionId1);
+
+		final ApplicationDto applicationDto2 = methodResponse.getApplications().get(1);
+		assertThat(applicationDto2.getApplicationFormName()).isEqualTo(application2.getApplicationName());
+		assertThat(applicationDto2.getGgisReferenceNumber()).isEqualTo(scheme2.getGgisIdentifier());
+		assertThat(applicationDto2.getSubmissions()).hasSize(1);
+		assertThat(applicationDto2.getSubmissions().get(0).getSubmissionId()).isEqualTo(submissionId2);
 	}
 
 }

--- a/src/test/java/gov/cabinetoffice/api/mappers/SubmissionMapperTest.java
+++ b/src/test/java/gov/cabinetoffice/api/mappers/SubmissionMapperTest.java
@@ -237,9 +237,6 @@ class SubmissionMapperTest {
 
 	final SubmissionDTO submissionDTO = SubmissionDTO.builder()
 		.submissionId(SUBMISSION_ID)
-		.applicationFormName(application.getApplicationName())
-		.ggisReferenceNumber(scheme.getGgisIdentifier())
-		.grantAdminEmailAddress(scheme.getEmail())
 		.submittedTimeStamp(zonedDateTime)
 		.grantApplicantEmailAddress(scheme.getEmail())
 		.sections(List.of(submissionSectionDTO1, submissionSectionDTO2))
@@ -254,6 +251,34 @@ class SubmissionMapperTest {
 	}
 
 	@Test
+	void submissionToSubmissionDto_ReturnsNull() {
+		SubmissionDTO result = submissionMapper.submissionToSubmissionDto(null);
+		assertThat(result).isNull();
+	}
+
+	@Test
+	void submissionToSubmissionDto_GrantAdminEmailAddress_isNull_IfSubmissionSchemeIsNull() {
+		final Submission submission = Submission.builder()
+				.definition(SubmissionDefinition.builder().build())
+				.build();
+		SubmissionDTO result = submissionMapper.submissionToSubmissionDto(submission);
+		assertThat(result.getGrantApplicantEmailAddress()).isNull();
+	}
+
+	@Test
+	void submissionToSubmissionDto_GrantAdminEmailAddress_isNull_IfSubmissionSchemeEmailAddressIsNull() {
+		final SchemeEntity scheme = SchemeEntity.builder().build();
+		final Submission submission = Submission.builder()
+				.definition(SubmissionDefinition.builder().build())
+				.scheme(scheme)
+				.build();
+
+		final SubmissionDTO result = submissionMapper.submissionToSubmissionDto(submission);
+
+		assertThat(result.getGrantApplicantEmailAddress()).isNull();
+	}
+
+	@Test
 	void mapSections() {
 		List<SubmissionSectionDTO> result = submissionMapper.mapSections(submission.getDefinition().getSections());
 		assertThat(result).isEqualTo(List.of(submissionSectionDTO1, submissionSectionDTO2));
@@ -263,6 +288,12 @@ class SubmissionMapperTest {
 	void submissionSectionToSubmissionSectionDto() {
 		SubmissionSectionDTO result = submissionMapper.submissionSectionToSubmissionSectionDto(section1);
 		assertThat(result).isEqualTo(submissionSectionDTO1);
+	}
+
+	@Test
+	void submissionSectionToSubmissionSectionDto_ReturnsNull() {
+		SubmissionSectionDTO result = submissionMapper.submissionSectionToSubmissionSectionDto(null);
+		assertThat(result).isNull();
 	}
 
 	@Test
@@ -283,6 +314,30 @@ class SubmissionMapperTest {
 	void submissionQuestionToSubmissionQuestionDto() {
 		SubmissionQuestionDTO result = submissionMapper.submissionQuestionToSubmissionQuestionDto(question1);
 		assertThat(result).isEqualTo(questionDTO1);
+	}
+
+	@Test
+	void submissionQuestionToSubmissionQuestionDto_HandlesNullValues() {
+		final String questionTitle = "Enter the name of your organisation";
+		final SubmissionQuestion question1 = SubmissionQuestion.builder()
+				.questionId(QUESTION_ID_1)
+				.profileField("ORG_NAME")
+				.fieldTitle(questionTitle)
+				.hintText(
+						"This is the official name of your organisation. It could be the name that is registered with Companies House or the Charities Commission")
+				.responseType(ResponseTypeEnum.ShortAnswer)
+				.response(null)
+				.multiResponse(null)
+				.validation(SubmissionQuestionValidation.builder().mandatory(true).minLength(2).maxLength(250).build())
+				.build();
+
+		final SubmissionQuestionDTO dto = SubmissionQuestionDTO.builder()
+				.questionId(QUESTION_ID_1)
+				.questionTitle(questionTitle)
+				.build();
+
+		SubmissionQuestionDTO result = submissionMapper.submissionQuestionToSubmissionQuestionDto(question1);
+		assertThat(result).isEqualTo(dto);
 	}
 
 	@Test

--- a/src/test/java/gov/cabinetoffice/api/mappers/SubmissionMapperTestData.java
+++ b/src/test/java/gov/cabinetoffice/api/mappers/SubmissionMapperTestData.java
@@ -15,6 +15,7 @@ import gov.cabinetoffice.api.models.submission.SubmissionQuestionValidation;
 import gov.cabinetoffice.api.models.submission.SubmissionSection;
 
 import java.time.Instant;
+import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.ZonedDateTime;
 import java.util.List;
@@ -94,18 +95,23 @@ public class SubmissionMapperTestData {
             .validation(SubmissionQuestionValidation.builder().minLength(5).maxLength(100).build())
             .build();
 
+    private static final String[] date = { "01", "12", "1987" };
+    private static final SubmissionQuestion question4 = SubmissionQuestion.builder()
+            .questionId("test")
+            .responseType(ResponseTypeEnum.Date)
+            .multiResponse(date)
+            .build();
+
     private static final SubmissionSection section1 = SubmissionSection.builder()
             .sectionId(SECTION_ID_1)
             .sectionTitle(SECTION_TITLE_1)
             .sectionStatus(SubmissionSectionStatus.IN_PROGRESS)
-            .questions(List.of(question1, question2, question3))
+            .questions(List.of(question1, question2, question3, question4))
             .build();
 
     private static final SubmissionDefinition definition = SubmissionDefinition.builder()
             .sections(List.of(section1))
             .build();
-
-    private static final String[] date = { "01", "12", "1987" };
 
     private static final long APPLICANT_ID = 1;
 
@@ -150,6 +156,7 @@ public class SubmissionMapperTestData {
             .submittedDate(zonedDateTime)
             .build();
 
+
     private static final SubmissionQuestionDTO questionDTO1 = SubmissionQuestionDTO.builder()
             .questionId(question1.getQuestionId())
             .questionTitle(question1.getFieldTitle())
@@ -176,17 +183,20 @@ public class SubmissionMapperTestData {
             .questionResponse(addressDTO)
             .build();
 
+    private static final SubmissionQuestionDTO questionDTO4 = SubmissionQuestionDTO.builder()
+            .questionId(question4.getQuestionId())
+            .questionTitle(question4.getFieldTitle())
+            .questionResponse(LocalDate.of(1987, 12, 1))
+            .build();
+
     private static final SubmissionSectionDTO submissionSectionDTO1 = SubmissionSectionDTO.builder()
             .sectionId(SECTION_ID_1)
             .sectionTitle(SECTION_TITLE_1)
-            .questions(List.of(questionDTO1, questionDTO2, questionDTO3))
+            .questions(List.of(questionDTO1, questionDTO2, questionDTO3, questionDTO4))
             .build();
 
     private static final SubmissionDTO submissionDTO = SubmissionDTO.builder()
             .submissionId(SUBMISSION_ID)
-            .applicationFormName(application.getApplicationName())
-            .ggisReferenceNumber(scheme.getGgisIdentifier())
-            .grantAdminEmailAddress(scheme.getEmail())
             .submittedTimeStamp(zonedDateTime)
             .grantApplicantEmailAddress(scheme.getEmail())
             .sections(List.of(submissionSectionDTO1))

--- a/src/test/java/gov/cabinetoffice/api/mappers/SubmissionMapperTestData.java
+++ b/src/test/java/gov/cabinetoffice/api/mappers/SubmissionMapperTestData.java
@@ -1,0 +1,210 @@
+package gov.cabinetoffice.api.mappers;
+
+import gov.cabinetoffice.api.dtos.submission.AddressDTO;
+import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
+import gov.cabinetoffice.api.dtos.submission.SubmissionQuestionDTO;
+import gov.cabinetoffice.api.dtos.submission.SubmissionSectionDTO;
+import gov.cabinetoffice.api.entities.*;
+import gov.cabinetoffice.api.enums.ResponseTypeEnum;
+import gov.cabinetoffice.api.enums.SubmissionSectionStatus;
+import gov.cabinetoffice.api.enums.SubmissionStatus;
+import gov.cabinetoffice.api.models.application.ApplicationDefinition;
+import gov.cabinetoffice.api.models.submission.SubmissionDefinition;
+import gov.cabinetoffice.api.models.submission.SubmissionQuestion;
+import gov.cabinetoffice.api.models.submission.SubmissionQuestionValidation;
+import gov.cabinetoffice.api.models.submission.SubmissionSection;
+
+import java.time.Instant;
+import java.time.LocalDateTime;
+import java.time.ZonedDateTime;
+import java.util.List;
+import java.util.UUID;
+
+public class SubmissionMapperTestData {
+
+    private static final int APPLICATION_ID = 1;
+
+    private static final LocalDateTime timestamp = LocalDateTime.now();
+
+    private static final ZonedDateTime zonedDateTime = ZonedDateTime.now();
+
+    private static final Instant instant = Instant.now();
+
+    private static final String QUESTION_ID_1 = "APPLICANT_ORG_NAME";
+
+    private static final String QUESTION_ID_2 = "APPLICANT_ORG_ADDRESS";
+
+    private static final String QUESTION_ID_3 = "APPLICANT_ORG_COMPANIES_HOUSE";
+
+    private static final String SECTION_ID_1 = "ELIGIBILITY";
+
+    private static final String SECTION_TITLE_1 = "Eligibility";
+
+    private static final SchemeEntity scheme = SchemeEntity.builder()
+            .id(1)
+            .version(1)
+            .funderId(1)
+            .lastUpdated(instant)
+            .email("test@and.digital")
+            .name("Test Scheme")
+            .ggisIdentifier("Test GGIS Identifier")
+            .build();
+
+    private static final ApplicationFormEntity application = ApplicationFormEntity.builder()
+            .grantApplicationId(APPLICATION_ID)
+            .applicationName("Test Application")
+            .created(instant)
+            .lastUpdated(instant)
+            .definition(new ApplicationDefinition())
+            .grantSchemeId(scheme.getId())
+            .version(1)
+            .lastUpdateBy(1)
+            .build();
+
+    private static final SubmissionQuestion question1 = SubmissionQuestion.builder()
+            .questionId(QUESTION_ID_1)
+            .profileField("ORG_NAME")
+            .fieldTitle("Enter the name of your organisation")
+            .hintText(
+                    "This is the official name of your organisation. It could be the name that is registered with Companies House or the Charities Commission")
+            .responseType(ResponseTypeEnum.ShortAnswer)
+            .response("organisationName")
+            .validation(SubmissionQuestionValidation.builder().mandatory(true).minLength(2).maxLength(250).build())
+            .build();
+
+    private static final String[] address = { "addressLine1", "addressLine2", "town", "county", "postcode" };
+
+    private static final SubmissionQuestion question2 = SubmissionQuestion.builder()
+            .questionId(QUESTION_ID_2)
+            .profileField("ORG_ADDRESS")
+            .fieldTitle("Enter your organisation's address")
+            .responseType(ResponseTypeEnum.AddressInput)
+            .multiResponse(address)
+            .validation(SubmissionQuestionValidation.builder().mandatory(true).build())
+            .build();
+
+    private static final SubmissionQuestion question3 = SubmissionQuestion.builder()
+            .questionId(QUESTION_ID_3)
+            .profileField("ORG_COMPANIES_HOUSE")
+            .fieldTitle("Does your organisation have a Companies House number?")
+            .hintText(
+                    "Funding organisation might use this to identify your organisation when you apply for a grant. It might also be used to check your organisation is legitimate.")
+            .responseType(ResponseTypeEnum.YesNo)
+            .response("yes")
+            .validation(SubmissionQuestionValidation.builder().minLength(5).maxLength(100).build())
+            .build();
+
+    private static final SubmissionSection section1 = SubmissionSection.builder()
+            .sectionId(SECTION_ID_1)
+            .sectionTitle(SECTION_TITLE_1)
+            .sectionStatus(SubmissionSectionStatus.IN_PROGRESS)
+            .questions(List.of(question1, question2, question3))
+            .build();
+
+    private static final SubmissionDefinition definition = SubmissionDefinition.builder()
+            .sections(List.of(section1))
+            .build();
+
+    private static final String[] date = { "01", "12", "1987" };
+
+    private static final long APPLICANT_ID = 1;
+
+    private static final long PROFILE_ID = 1;
+
+    private static final GrantApplicantOrganisationProfile grantApplicantOrganisationProfile = GrantApplicantOrganisationProfile
+            .builder()
+            .id(PROFILE_ID)
+            .legalName("AND Digital")
+            .charityCommissionNumber("45")
+            .companiesHouseNumber("000010")
+            .addressLine1("AND Digital")
+            .addressLine2("9 George Square")
+            .town("Glasgow")
+            .postcode("G2 1QQ")
+            .county("Renfrewshire")
+            .build();
+
+    private static final UUID APPLICANT_USER_ID = UUID.fromString("75ab5fbd-0682-4d3d-a467-01c7a447f07c");
+
+    private static final GrantApplicant grantApplicant = GrantApplicant.builder()
+            .id(APPLICANT_ID)
+            .userId(APPLICANT_USER_ID)
+            .organisationProfile(grantApplicantOrganisationProfile)
+            .build();
+
+    private static final UUID SUBMISSION_ID = UUID.fromString("1c2eabf0-b33c-433a-b00f-e73d8efca929");
+
+    private static final Submission submission = Submission.builder()
+            .id(SUBMISSION_ID)
+            .applicant(grantApplicant)
+            .scheme(scheme)
+            .application(application)
+            .version(1)
+            .created(timestamp)
+            .createdBy(grantApplicant)
+            .lastUpdated(timestamp)
+            .lastUpdatedBy(grantApplicant)
+            .applicationName("Test Submission")
+            .status(SubmissionStatus.IN_PROGRESS)
+            .definition(definition)
+            .submittedDate(zonedDateTime)
+            .build();
+
+    private static final SubmissionQuestionDTO questionDTO1 = SubmissionQuestionDTO.builder()
+            .questionId(question1.getQuestionId())
+            .questionTitle(question1.getFieldTitle())
+            .questionResponse(question1.getResponse())
+            .build();
+
+    private static final SubmissionQuestionDTO questionDTO3 = SubmissionQuestionDTO.builder()
+            .questionId(question3.getQuestionId())
+            .questionTitle(question3.getFieldTitle())
+            .questionResponse(question3.getResponse())
+            .build();
+
+    private static final AddressDTO addressDTO = AddressDTO.builder()
+            .addressLine1(address[0])
+            .addressLine2(address[1])
+            .town(address[2])
+            .county(address[3])
+            .postcode(address[4])
+            .build();
+
+    private static final SubmissionQuestionDTO questionDTO2 = SubmissionQuestionDTO.builder()
+            .questionId(question2.getQuestionId())
+            .questionTitle(question2.getFieldTitle())
+            .questionResponse(addressDTO)
+            .build();
+
+    private static final SubmissionSectionDTO submissionSectionDTO1 = SubmissionSectionDTO.builder()
+            .sectionId(SECTION_ID_1)
+            .sectionTitle(SECTION_TITLE_1)
+            .questions(List.of(questionDTO1, questionDTO2, questionDTO3))
+            .build();
+
+    private static final SubmissionDTO submissionDTO = SubmissionDTO.builder()
+            .submissionId(SUBMISSION_ID)
+            .applicationFormName(application.getApplicationName())
+            .ggisReferenceNumber(scheme.getGgisIdentifier())
+            .grantAdminEmailAddress(scheme.getEmail())
+            .submittedTimeStamp(zonedDateTime)
+            .grantApplicantEmailAddress(scheme.getEmail())
+            .sections(List.of(submissionSectionDTO1))
+            .build();
+
+    public static Submission getSubmission() {
+        return submission;
+    }
+
+    public static SubmissionDTO getSubmissionDto() {
+        return submissionDTO;
+    }
+
+    public static SubmissionSection getSubmissionSection() {
+        return section1;
+    }
+
+    public static SubmissionSectionDTO getSubmissionSectionDto() {
+        return submissionSectionDTO1;
+    }
+}

--- a/src/test/java/gov/cabinetoffice/api/services/SubmissionsServiceTest.java
+++ b/src/test/java/gov/cabinetoffice/api/services/SubmissionsServiceTest.java
@@ -1,5 +1,7 @@
 package gov.cabinetoffice.api.services;
 
+import gov.cabinetoffice.api.dtos.submission.ApplicationDto;
+import gov.cabinetoffice.api.dtos.submission.ApplicationListDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionDTO;
 import gov.cabinetoffice.api.dtos.submission.SubmissionListDTO;
 import gov.cabinetoffice.api.entities.Submission;
@@ -44,28 +46,29 @@ class SubmissionsServiceTest {
 				.build();
 		final List<SubmissionDTO> submissionDTOList = List.of(submissionDto);
 
+		final ApplicationDto application = ApplicationDto.builder()
+				.ggisReferenceNumber("SCH-001")
+				.applicationFormName("Woodland services grant")
+				.grantAdminEmailAddress("gavin.cook@and.digital")
+				.submissions(submissionDTOList)
+				.build();
+		final List<ApplicationDto> applications = List.of(application);
+
+		final ApplicationListDTO applicationListDTO = ApplicationListDTO.builder()
+				.numberOfResults(applications.size())
+				.applications(applications)
+				.build();
+
 		when(submissionRepository.findBySchemeFunderIdAndSchemeGgisIdentifier(FUNDING_ORG_ID, GGIS_REFERENCE_NUMBER))
 				.thenReturn(submissions);
 
-		when(submissionMapper.submissionToSubmissionDto(submission))
-				.thenReturn(submissionDto);
+		when(submissionMapper.submissionListToApplicationListDto(submissions))
+				.thenReturn(applicationListDTO);
 
-		final SubmissionListDTO methodResponse = submissionsService.getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORG_ID, GGIS_REFERENCE_NUMBER);
+		final ApplicationListDTO methodResponse = submissionsService.getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORG_ID, GGIS_REFERENCE_NUMBER);
 
 		verify(submissionRepository).findBySchemeFunderIdAndSchemeGgisIdentifier(FUNDING_ORG_ID, GGIS_REFERENCE_NUMBER);
-		assertThat(methodResponse.getNumberOfResults()).isEqualTo(List.of(submission).size());
-		assertThat(methodResponse.getSubmissions()).isEqualTo(submissionDTOList);
-	}
-
-	@Test
-	void getSubmissionsByFundingOrgIdAndGgisReferenceNum_ThrowsSubmissionNotFoundException() {
-
-		when(submissionRepository.findBySchemeFunderIdAndSchemeGgisIdentifier(FUNDING_ORG_ID, GGIS_REFERENCE_NUMBER))
-				.thenReturn(Collections.emptyList());
-
-		assertThatExceptionOfType(SubmissionNotFoundException.class)
-				.isThrownBy(() -> submissionsService.getSubmissionsByFundingOrgIdAndGgisReferenceNum(FUNDING_ORG_ID, GGIS_REFERENCE_NUMBER))
-				.withMessage("No submissions found");
+		assertThat(methodResponse).isEqualTo(applicationListDTO);
 	}
 
 	@Test
@@ -80,27 +83,28 @@ class SubmissionsServiceTest {
 				.build();
 		final List<SubmissionDTO> submissionDTOList = List.of(submissionDto);
 
+		final ApplicationDto application = ApplicationDto.builder()
+				.ggisReferenceNumber("SCH-001")
+				.applicationFormName("Woodland services grant")
+				.grantAdminEmailAddress("gavin.cook@and.digital")
+				.submissions(submissionDTOList)
+				.build();
+		final List<ApplicationDto> applications = List.of(application);
+
+		final ApplicationListDTO applicationListDTO = ApplicationListDTO.builder()
+				.numberOfResults(applications.size())
+				.applications(applications)
+				.build();
+
 		when(submissionRepository.findBySchemeFunderId(FUNDING_ORG_ID))
 				.thenReturn(submissions);
 
-		when(submissionMapper.submissionToSubmissionDto(submission))
-				.thenReturn(submissionDto);
+		when(submissionMapper.submissionListToApplicationListDto(submissions))
+				.thenReturn(applicationListDTO);
 
-		final SubmissionListDTO methodResponse = submissionsService.getSubmissionsByFundingOrgId(FUNDING_ORG_ID);
+		final ApplicationListDTO methodResponse = submissionsService.getSubmissionsByFundingOrgId(FUNDING_ORG_ID);
 
 		verify(submissionRepository).findBySchemeFunderId(FUNDING_ORG_ID);
-		assertThat(methodResponse.getNumberOfResults()).isEqualTo(List.of(submission).size());
-		assertThat(methodResponse.getSubmissions()).isEqualTo(submissionDTOList);
-	}
-
-	@Test
-	void getSubmissionsByFundingOrgId_ThrowsSubmissionNotFoundException() {
-
-		when(submissionRepository.findBySchemeFunderId(FUNDING_ORG_ID))
-				.thenReturn(Collections.emptyList());
-
-		assertThatExceptionOfType(SubmissionNotFoundException.class)
-				.isThrownBy(() -> submissionsService.getSubmissionsByFundingOrgId(FUNDING_ORG_ID))
-				.withMessage("No submissions found");
+		assertThat(methodResponse).isEqualTo(applicationListDTO);
 	}
 }


### PR DESCRIPTION
Reformatting the API data model to return data in a more appropriate format. Shifting application specific information up one level into an application object then providing that object with a list of submissions. This will allow third party systems to more easily process submission data as it will be grouped under a GGIS identifier and an application form title. See below: 

```
{
    "numberOfResults": 1,
    "applications": [
        {
            "applicationFormName": "Woodland Partnership Application",
            "grantAdminEmailAddress": "chris.steele@and.digital",
            "ggisReferenceNumber": "SCH-000003589",
            "submissions": [
                {
                    "submissionId": "3a6cfe2d-bf58-440d-9e07-3579c7dcf207",
                    "grantApplicantEmailAddress": "chris.steele@and.digital",
                    "submittedTimeStamp": "2022-09-27T11:34:56Z",
                    "sections": [
                        {
                            "sectionId": "ELIGIBILITY",
                            "sectionTitle": "Eligibility",
                            "questions": [
                                {
                                    "questionId": "ELIGIBILITY",
                                    "questionTitle": "Do you confirm that your organisation is eligible to recieve this funding? ",
                                    "questionResponse": "Yes"
                                }
                            ]
                        }
                        ...
                    ]
                },
                ...
            ]
        }, 
        ...
    ]
}
```

Additionally, added more tests to increase coverage, refactored some duplicated code and performed some general tidy up. 