### PR TITLE
 TMI2-323/address-high-dependency-vulnerabilities

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.0</version>
+		<version>3.1.4</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>gov.cabinetoffice.api</groupId>


### PR DESCRIPTION
* Updated spring boot starter parent to 3.1.4 to patch vulnerability in tomcat-embed-core.