### PR TITLE
TMI2-410/dependency-vulnerabilities

### DIFF
--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: TEST - filespace
-        run: ls ./api && cd ./api && pwd
+        run: cd api && pwd
 
       - name: Checkout API
         uses: actions/checkout@v3

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -38,7 +38,7 @@ jobs:
         run: mvn -B package --file pom.xml -DskipTests
 
       - name: TEST - List Files in Workspace
-        run: ls ${{github.workspace}} && cat dependency-check-suppression.xml
+        run: ls ${{github.workspace}}/api
 
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@main

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: TEST - filespace
-        run: ls .
+        run: ls && pwd
 
       - name: Checkout API
         uses: actions/checkout@v3

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: TEST - filespace
-        run: ls && pwd
+        run: ls ./api && cd ./api && pwd
 
       - name: Checkout API
         uses: actions/checkout@v3

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --suppression "../../dependency-check-suppression.xml"
+            --suppression "/dependency-check-suppression.xml"
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -27,7 +27,7 @@ jobs:
           path: api
 
       - name: TEST - filespace
-        run: ls ${{github.workspace}}
+        run: ls
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: TEST - filespace
-        run: cd ${{github.workspace}}/api && pwd
+        run: ls ${{github.workspace}}
 
       - name: Checkout API
         uses: actions/checkout@v3

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -21,6 +21,9 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
+      - name: TEST - filespace
+        run: ls .
+
       - name: Checkout API
         uses: actions/checkout@v3
         with:
@@ -48,9 +51,9 @@ jobs:
           format: "HTML"
           args: >
             --failOnCVSS 7.0
+            --suppress ${{github.workspace}}/api/dependency-check-suppression.xml
             --enableRetired
             --disableOssIndex true
-            --suppress ${{github.workspace}}/api/dependency-check-suppression.xml
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -37,9 +37,6 @@ jobs:
         working-directory: ./api
         run: mvn -B package --file pom.xml -DskipTests
 
-      - name: TEST - Run dependency check command
-        run: dependency-check --project "gap-find-open-data-api" --scan . --failOnCVSS 7.0 --suppression "${{github.workspace}}/api/dependency-check-suppression.xml"
-
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
         env:

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -22,7 +22,7 @@ jobs:
 
     steps:
       - name: TEST - filespace
-        run: cd api && pwd
+        run: cd ${{github.workspace}}/api && pwd
 
       - name: Checkout API
         uses: actions/checkout@v3

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -51,6 +51,7 @@ jobs:
             --suppress ./api/dependency-check-suppression.xml
             --enableRetired
             --disableOssIndex true
+            --disableRetireJS true
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --exclude  **/netty-transport-4.1.100.Final.jar/
+            --exclude "io.netty:netty-transport"
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --suppression "\dependency-check-suppression.xml"
+            --suppression dependency-check-suppression.xml
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -27,7 +27,7 @@ jobs:
           path: api
 
       - name: TEST - filespace
-        run: ls ./api
+        run: cat ./api/dependency-check-suppression.xml && echo "file present"
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3
@@ -51,7 +51,7 @@ jobs:
           format: "HTML"
           args: >
             --failOnCVSS 7.0
-            --suppress ${{github.workspace}}/api/dependency-check-suppression.xml
+            --suppress ./api/dependency-check-suppression.xml
             --enableRetired
             --disableOssIndex true
 

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,6 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
+            --exclude  **/netty-transport-4.1.100.Final.jar/
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -37,6 +37,9 @@ jobs:
         working-directory: ./api
         run: mvn -B package --file pom.xml -DskipTests
 
+      - name: TEST - List Files in Workspace
+        run: ls ${{github.workspace}} && cat dependency-check-suppression.xml
+
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
         env:

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --exclude "io.netty:netty-transport"
+            --exclude "**/io.netty/netty-transport/**"
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --suppression "/dependency-check-suppression.xml"
+            --suppression "\dependency-check-suppression.xml"
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -21,13 +21,13 @@ jobs:
     runs-on: ubuntu-latest
 
     steps:
-      - name: TEST - filespace
-        run: ls ${{github.workspace}}
-
       - name: Checkout API
         uses: actions/checkout@v3
         with:
           path: api
+
+      - name: TEST - filespace
+        run: ls ${{github.workspace}}
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --exclude "**/io.netty/netty-transport/**"
+            --suppression "../../dependency-check-suppression.xml"
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -37,8 +37,8 @@ jobs:
         working-directory: ./api
         run: mvn -B package --file pom.xml -DskipTests
 
-      - name: TEST - List files in Workspace
-        run: ls ${{github.workspace}}/api && cat ${{github.workspace}}/api/dependency-check-suppression.xml
+      - name: TEST - Run dependency check command
+        run: dependency-check --project "gap-find-open-data-api" --scan . --failOnCVSS 7.0 --suppression "${{github.workspace}}/api/dependency-check-suppression.xml"
 
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
@@ -53,7 +53,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --suppression "${{github.workspace}}/api/dependency-check-suppression.xml"
+            --suppressionFiles "${{github.workspace}}/api/dependency-check-suppression.xml"
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -37,6 +37,9 @@ jobs:
         working-directory: ./api
         run: mvn -B package --file pom.xml -DskipTests
 
+      - name: TEST - List files in Workspace
+        run: ls ${{github.workspace}}/api && cat ${{github.workspace}}/api/dependency-check-suppression.xml
+
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
         env:

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --suppressionFiles "${{github.workspace}}/api/dependency-check-suppression.xml"
+            --suppress ${{github.workspace}}/api/dependency-check-suppression.xml
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -27,7 +27,7 @@ jobs:
           path: api
 
       - name: TEST - filespace
-        run: ls
+        run: ls ./api
 
       - name: Set up JDK 17
         uses: actions/setup-java@v3

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -37,9 +37,6 @@ jobs:
         working-directory: ./api
         run: mvn -B package --file pom.xml -DskipTests
 
-      - name: TEST - List Files in Workspace
-        run: ls ${{github.workspace}}/api
-
       - name: Dependency Check
         uses: dependency-check/Dependency-Check_Action@main
         env:
@@ -53,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --suppression "${{github.workspace}}/dependency-check-suppression.xml"
+            --suppression "${{github.workspace}}/api/dependency-check-suppression.xml"
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -26,9 +26,6 @@ jobs:
         with:
           path: api
 
-      - name: TEST - filespace
-        run: cat ./api/dependency-check-suppression.xml && echo "file present"
-
       - name: Set up JDK 17
         uses: actions/setup-java@v3
         with:

--- a/.github/workflows/feature.yml
+++ b/.github/workflows/feature.yml
@@ -50,7 +50,7 @@ jobs:
             --failOnCVSS 7.0
             --enableRetired
             --disableOssIndex true
-            --suppression dependency-check-suppression.xml
+            --suppression "${{github.workspace}}/dependency-check-suppression.xml"
 
       - name: Upload Dependency Check Report
         if: success() || failure()

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,0 +1,92 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+      Suppressing netty-transport-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+      ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-transport-classes-epoll-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-classes\-epoll@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-transport-native-unix-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-native\-unix\-common@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-codec-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-buffer-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-buffer@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-common@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-handler-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-resolver-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-resolver@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-codec-http-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec\-http@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+
+    <suppress until="2023-11-09Z">
+        <notes><![CDATA[
+   Suppressing netty-codec-http2-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
+   ]]></notes>
+        <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec\-http2@.*$</packageUrl>
+        <cpe>cpe:/a:netty:netty</cpe>
+        <cve>CVE-2023-4586</cve>
+    </suppress>
+</suppressions>

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -5,7 +5,6 @@
       Suppressing netty-transport-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
       ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -14,7 +13,6 @@
    Suppressing netty-transport-classes-epoll-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-classes\-epoll@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -23,7 +21,6 @@
    Suppressing netty-transport-native-unix-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-transport\-native\-unix\-common@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -32,7 +29,6 @@
    Suppressing netty-codec-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -41,7 +37,6 @@
    Suppressing netty-buffer-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-buffer@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -50,7 +45,6 @@
    Suppressing netty-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-common@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -59,7 +53,6 @@
    Suppressing netty-handler-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-handler@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -68,7 +61,6 @@
    Suppressing netty-resolver-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-resolver@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -77,7 +69,6 @@
    Suppressing netty-codec-http-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec\-http@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 
@@ -86,7 +77,6 @@
    Suppressing netty-codec-http2-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
         <packageUrl regex="true">^pkg:maven/io\.netty/netty\-codec\-http2@.*$</packageUrl>
-        <cpe>cpe:/a:netty:netty</cpe>
         <cve>CVE-2023-4586</cve>
     </suppress>
 </suppressions>

--- a/dependency-check-suppression.xml
+++ b/dependency-check-suppression.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <suppressions xmlns="https://jeremylong.github.io/DependencyCheck/dependency-suppression.1.3.xsd">
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
       Suppressing netty-transport-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
       ]]></notes>
@@ -8,7 +8,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-transport-classes-epoll-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -16,7 +16,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-transport-native-unix-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -24,7 +24,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-codec-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -32,7 +32,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-buffer-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -40,7 +40,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-common-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -48,7 +48,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-handler-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -56,7 +56,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-resolver-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -64,7 +64,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-codec-http-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>
@@ -72,7 +72,7 @@
         <cve>CVE-2023-4586</cve>
     </suppress>
 
-    <suppress until="2023-11-09Z">
+    <suppress until="2023-12-01Z">
         <notes><![CDATA[
    Suppressing netty-codec-http2-4.1.100.Final.jar CVE-2023-4586 as we need to wait for Netty5 to release.
    ]]></notes>

--- a/pom.xml
+++ b/pom.xml
@@ -15,7 +15,7 @@
 	<description>Demo project for Spring Boot</description>
 	<properties>
 		<java.version>17</java.version>
-		<aws.java.sdk.version>2.20.45</aws.java.sdk.version>
+		<aws.java.sdk.version>2.21.5</aws.java.sdk.version>
 		<spring-security.version>6.1.4</spring-security.version>
 	</properties>
 	<dependencyManagement>

--- a/pom.xml
+++ b/pom.xml
@@ -5,7 +5,7 @@
 	<parent>
 		<groupId>org.springframework.boot</groupId>
 		<artifactId>spring-boot-starter-parent</artifactId>
-		<version>3.1.4</version>
+		<version>3.1.5</version>
 		<relativePath/> <!-- lookup parent from repository -->
 	</parent>
 	<groupId>gov.cabinetoffice.api</groupId>

--- a/pom.xml
+++ b/pom.xml
@@ -133,10 +133,7 @@
 				<configuration>
 					<failBuildOnCVSS>7.0</failBuildOnCVSS>
 					<ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
-					<excludes>
-						<groupId>io.netty</groupId>
-						<artifactId>netty-transport</artifactId>
-					</excludes>
+					<suppressionFile>dependency-check-suppression.xml</suppressionFile>
 				</configuration>
 				<executions>
 					<execution>

--- a/pom.xml
+++ b/pom.xml
@@ -133,6 +133,10 @@
 				<configuration>
 					<failBuildOnCVSS>7.0</failBuildOnCVSS>
 					<ossindexAnalyzerEnabled>false</ossindexAnalyzerEnabled>
+					<excludes>
+						<groupId>io.netty</groupId>
+						<artifactId>netty-transport</artifactId>
+					</excludes>
 				</configuration>
 				<executions>
 					<execution>


### PR DESCRIPTION
Updated spring boot starter parent to 3.1.5 to patch vulnerability CVE-2023-44487(7.5).